### PR TITLE
docs(readme): fix submodule section wording and URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,13 +634,13 @@ submodules under `tools/`:
 | [Francinette][francinette] | `tools/francinette` | Python piscine tester |
 | [mini-moulinette][mini-moulinette] | `tools/mini-moulinette` | Local moulinette runner |
 
-After cloning, you can initialise the submodules in one step:
+When cloning, initialise the submodules in one step:
 
 ```bash
-git clone --recurse-submodules https://github.com/qlrd/monsieur-ganesha
+git clone --recurse-submodules <repo-url>
 ```
 
-Or, if you have already cloned the repository:
+After cloning, initialise submodules with:
 
 ```bash
 git submodule update --init --recursive


### PR DESCRIPTION
## Summary

- Replaces misleading "After cloning" heading (followed by a `git clone` command) with "When cloning"
- Replaces hardcoded `https://github.com/qlrd/monsieur-ganesha` with `<repo-url>` placeholder so instructions work for forks
- Renames "Or, if you have already cloned the repository" to "After cloning" for the `git submodule update --init --recursive` step

Fixes the mismatch flagged in [PR #13 review thread](https://github.com/qlrd/monsieur-ganesha/pull/13#discussion_r2897697051).
Also resolves the content conflict between `main` and `ci/add-github-actions-coverage` on these lines.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] `git clone --recurse-submodules <repo-url>` section is under "When cloning"
- [ ] `git submodule update --init --recursive` section is under "After cloning"