### PR TITLE
feat(compiler): use cc instead of gcc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ project adheres to [Semantic Versioning][semver].
 - `norminette` hook: validates staged `.c` and `.h` files against the
   42 school norm by running the `norminette` CLI.
 - `c-compiler` hook: checks syntax of each staged `.c` file with
-  `gcc -Wall -Wextra -Werror -fsyntax-only`. Files are compiled
+  `cc -Wall -Wextra -Werror -fsyntax-only`. Files are compiled
   individually so all errors are reported before the hook exits.
 - `forbidden-functions` hook: scans staged `.c` files for calls to
   functions listed in `.ganesha.toml` using word-boundary regex.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ src/ganesha/
 └── checks/
     ├── __init__.py
     ├── norminette.py   subprocess: norminette
-    ├── compiler.py     subprocess: gcc -fsyntax-only
+    ├── compiler.py     subprocess: cc -Wall -Wextra -Werror -fsyntax-only
     ├── forbidden.py    pure Python regex scan
     └── commit_msg.py   pure Python regex + gamification
 
@@ -81,7 +81,7 @@ called without `-m`. vim is the expected editor at 42 school.
 
 ## Key design decisions
 
-- `gcc -fsyntax-only` avoids `.o` file conflicts across files.
+- `cc -fsyntax-only` avoids `.o` file conflicts across files.
 - Forbidden regex `\b(func)\s*\(` so `ft_func(` is not flagged.
 - `commit_msg.check` strips `#` git comment lines first.
 - `load_config` returns `Config()` when `.ganesha.toml` absent.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ passes here, it will pass Moulinette on those checks.
 - Python 3.11 or later
 - `pre-commit` >= 3.0
 - `norminette` (for the norminette hook — `pip install norminette`)
-- `gcc` (for the compiler hook)
+- `cc` (typically GCC 11.4.0 on 42 school machines)
 
 ---
 
@@ -251,7 +251,7 @@ Error: SPC_BEFORE_OPERATOR  (line 3, col 5)
 
 ### c-compiler
 
-Runs `gcc -Wall -Wextra -Werror -fsyntax-only` on each staged `.c`
+Runs `cc -Wall -Wextra -Werror -fsyntax-only` on each staged `.c`
 file individually. Using `-fsyntax-only` avoids generating `.o` files
 and works correctly even when headers from other staged files are not
 yet on disk. All errors are reported before the hook exits.
@@ -607,7 +607,7 @@ src/ganesha/
   config.py         reads .ganesha.toml (tomllib — stdlib)
   checks/
     norminette.py   subprocess wrapper
-    compiler.py     gcc -fsyntax-only, one invocation per file
+    compiler.py     cc -Wall -Wextra -Werror -fsyntax-only
     forbidden.py    pure-Python regex scan, no subprocess
     commit_msg.py   CC 1.0.0 validator, gamification layer
     readme.py       README.md structural validator

--- a/src/ganesha/__init__.py
+++ b/src/ganesha/__init__.py
@@ -8,7 +8,7 @@ before every ``git commit`` in a 42 piscine repository:
     42 Norme using the official ``norminette`` tool.
 
 ``c-compiler``
-    Runs ``gcc -Wall -Wextra -Werror -fsyntax-only`` on each staged
+    Runs ``cc -Wall -Wextra -Werror -fsyntax-only`` on each staged
     ``.c`` file to catch compilation errors before they reach the
     repository.
 

--- a/src/ganesha/checks/__init__.py
+++ b/src/ganesha/checks/__init__.py
@@ -17,7 +17,7 @@ norminette
     Wraps the ``norminette`` CLI to enforce the 42 Norme on ``.c``
     and ``.h`` files.
 compiler
-    Wraps ``gcc -fsyntax-only`` to catch compilation errors before
+    Wraps ``cc -fsyntax-only`` to catch compilation errors before
     commit.
 forbidden
     Pure-Python regex scanner that detects calls to functions

--- a/src/ganesha/checks/compiler.py
+++ b/src/ganesha/checks/compiler.py
@@ -1,11 +1,11 @@
-"""C syntax checker via ``gcc -fsyntax-only``.
+"""C syntax checker via ``cc -fsyntax-only``.
 
 This module implements the ``c-compiler`` pre-commit hook.  It invokes
-``gcc`` on each staged ``.c`` file with the flags::
+``cc`` on each staged ``.c`` file with the flags::
 
     -Wall -Wextra -Werror -fsyntax-only
 
-The ``-fsyntax-only`` flag tells gcc to parse and type-check the file
+The ``-fsyntax-only`` flag tells cc to parse and type-check the file
 without emitting any object code, which avoids two common problems:
 
 1. **No ``.o`` conflicts** — multiple staged files can be checked
@@ -22,11 +22,11 @@ failures are printed before the function returns.
 
 Error output
 ------------
-gcc writes its error messages to *stderr* by default; this module
+cc writes its error messages to *stderr* by default; this module
 captures them and re-prints them to *stderr* unchanged.  The student
-sees the familiar gcc output they would get from running gcc manually.
+sees the familiar cc output they would get from running cc manually.
 
-If gcc is not installed the hook prints an installation hint and exits
+If cc is not installed the hook prints an installation hint and exits
 with code 1 instead of raising an unhandled :class:`FileNotFoundError`.
 """
 
@@ -36,9 +36,9 @@ from collections.abc import Sequence
 
 
 def check(files: Sequence[str]) -> bool:
-    """Run ``gcc -Wall -Wextra -Werror -fsyntax-only`` on each ``.c`` file.
+    """Run ``cc -Wall -Wextra -Werror -fsyntax-only`` on each ``.c`` file.
 
-    Iterates over *files*, skips non-``.c`` entries, and invokes gcc
+    Iterates over *files*, skips non-``.c`` entries, and invokes cc
     once per ``.c`` file.  Collects the results and returns ``False``
     if any file fails.
 
@@ -55,9 +55,9 @@ def check(files: Sequence[str]) -> bool:
     Returns:
         ``True`` if every ``.c`` file compiles without errors.
         ``True`` if *files* is empty or contains no ``.c`` files.
-        ``False`` if any file fails to compile.  gcc's error output is
+        ``False`` if any file fails to compile.  cc's error output is
         printed to *stderr* for each failing file.
-        ``False`` if gcc is not found; an installation hint is printed
+        ``False`` if cc is not found; an installation hint is printed
         to *stderr*.
 
     Examples:
@@ -85,7 +85,7 @@ def check(files: Sequence[str]) -> bool:
           Python from raising :class:`subprocess.CalledProcessError`
           on non-zero exit codes; the error is handled manually.
         * ``capture_output=True`` redirects both stdout and stderr from
-          gcc into the :class:`subprocess.CompletedProcess` result so
+          cc into the :class:`subprocess.CompletedProcess` result so
           they can be forwarded to *stderr* of the hook process.
     """
     c_files = [f for f in files if f.endswith(".c")]
@@ -98,15 +98,16 @@ def check(files: Sequence[str]) -> bool:
     for c_file in c_files:
         try:
             result = subprocess.run(
-                ["gcc", "-Wall", "-Wextra", "-Werror", "-fsyntax-only", c_file],
+                ["cc", "-Wall", "-Wextra", "-Werror", "-fsyntax-only", c_file],
                 capture_output=True,
                 text=True,
                 check=False,
             )
         except FileNotFoundError:
             print(
-                "ERRO: gcc não encontrado.\n"
-                "Instale: sudo apt install gcc  (ou equivalente)",
+                "ERRO: cc não encontrado.\n"
+                "Instale: sudo apt install build-essential "
+                "(ou equivalente)",
                 file=sys.stderr,
             )
             return False

--- a/src/ganesha/cli.py
+++ b/src/ganesha/cli.py
@@ -11,7 +11,7 @@ Subcommands
     Run the norminette check on the given files.
 
 ``ganesha compiler <files...>``
-    Run the gcc syntax check on the given files.
+    Run the cc syntax check on the given files.
 
 ``ganesha forbidden <files...>``
     Run the forbidden-function scan on the given files.  Reads the


### PR DESCRIPTION
## Summary

42 school machines invoke the compiler as `cc` (aliased to GCC 11.4.0),
not `gcc` directly. This PR aligns the hook and all documentation.

- `compiler.py`: `["gcc", ...]` → `["cc", ...]`; install hint updated
  to `build-essential`
- `__init__.py`, `checks/__init__.py`, `cli.py`: docstrings updated
- `README.md`: requirements + hook description
- `CHANGELOG.md`: hook entry

Carries forward the compiler change from #22 (closed — Copilot-authored).

## Test plan

- [x] `pylint src/ganesha/` — 10.00/10
- [x] `pytest` — 100 passed
- [ ] Verify `cc` resolves correctly on a 42 school machine