### PR TITLE
docs(readme): add curl alternative to installation one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Run the setup script from inside your piscine repository:
 
 ```bash
 wget -qO- https://raw.githubusercontent.com/qlrd/monsieur-ganesha/main/install.sh | bash
+# or
+curl -fsSL https://raw.githubusercontent.com/qlrd/monsieur-ganesha/main/install.sh | bash
 ```
 
 The script will:


### PR DESCRIPTION
## Summary

Adds a `curl` alternative alongside the existing `wget` one-liner:

```bash
wget -qO- https://raw.githubusercontent.com/qlrd/monsieur-ganesha/main/install.sh | bash
# or
curl -fsSL https://raw.githubusercontent.com/qlrd/monsieur-ganesha/main/install.sh | bash
```

42 school machines have both, but some students are more familiar with
one or the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)