### PR TITLE
fix(install): create .dawon.toml template and bump rev to v0.1.2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,114 @@
+# Copilot Instructions for monsieur-ganesha
+
+These instructions apply to all Copilot interactions in this
+repository: code review, chat, agent tasks, and PR generation.
+
+---
+
+## Companion project
+
+**dawon** (`https://github.com/qlrd/dawon`) is the companion
+submission evaluator for the 42 piscine.  The two projects are
+complementary:
+
+| Tool | Language | Role |
+|------|----------|------|
+| monsieur-ganesha | Python | Pre-commit hooks: norminette, compiler, forbidden functions, commit-message, README |
+| dawon | Rust | Submission evaluator: symbol, build, valgrind, harness (SHA-256) |
+
+When a change in monsieur-ganesha affects a check that dawon also
+performs, check whether dawon needs a corresponding update, and
+vice versa.  When opening an issue or PR that spans both repos,
+link them with `Refs qlrd/dawon#N` or `Refs qlrd/monsieur-ganesha#N`.
+
+---
+
+## Project summary
+
+monsieur-ganesha is a Python pre-commit hook suite for the 42 school
+piscine.  Named after Monsieur Ganesha, Directeur of the Conservatoire
+de Paris XLII.
+
+Hooks:
+
+| Hook | What it does |
+|------|--------------|
+| `norminette` | Runs norminette on staged `.c` and `.h` files |
+| `c-compiler` | Compiles each `.c` with `cc -Wall -Wextra -Werror` |
+| `forbidden-functions` | Regex scan for configurable forbidden functions |
+| `commit-message` | Enforces Conventional Commits 1.0.0 |
+| `readme` | Advisory README structural check (non-blocking) |
+
+---
+
+## Stack
+
+- Python 3.10+ (3.10.12 on 42 school Debian VMs)
+- `tomllib` (stdlib 3.11+) / `tomli` (backport for 3.10)
+- `uv` for environment and package management
+- `pytest` for tests, `black` + `isort` + `pylint` for quality
+
+---
+
+## Configuration file
+
+The config file is always `.ganesha.toml`.  Never write
+`.piscinette.toml` or any other name.
+
+---
+
+## Commit discipline
+
+- Follow **Conventional Commits 1.0.0**: `<type>[(<scope>)][!]: <description>`
+- Subject line ≤ 72 characters
+- Types: `feat` `fix` `docs` `style` `refactor` `perf` `test`
+  `build` `ci` `chore` `revert` `init` `lore`
+- `lore` is for in-world narrative commits (mascot artwork, character
+  descriptions, project lore) — only use in project-level repos, not
+  student submissions
+- Once the PR number is known, include it in commit metadata by
+  appending `(#N)` to the subject line or adding `Closes #N` /
+  `Refs #N` in the commit body footer
+- All commits must include `Signed-off-by:` (DCO)
+
+---
+
+## Code style
+
+- `black src/ tests/` — format before every commit
+- `isort src/ tests/` — sort imports
+- `pylint src/ganesha/` — zero warnings allowed
+- Prose (comments, docs, Markdown) wraps at 72 characters
+- No unnecessary dependencies — prefer stdlib where possible
+
+---
+
+## Pull request discipline
+
+- Open an issue before writing code for non-trivial changes
+- PR description must state: what, why, how tested
+- CI must be green before merging
+- Merge method: **Rebase and merge**
+
+---
+
+## Feedback loop with @copilot
+
+Every review comment, NACK, tACK, or concern posted in response
+to a Copilot-opened PR or Copilot comment **must** address
+`@copilot` directly.  This notifies the agent and keeps the
+review thread active.
+
+Examples:
+
+```
+@copilot NACK — remove the extra tomllib import before merging.
+
+@copilot tACK abc1234 — all 103 tests pass, pylint 10/10.
+
+@copilot the forbidden regex misses multi-line calls; fix it.
+```
+
+Do not leave review concerns as unaddressed prose.  If the
+concern is actionable, mention `@copilot` so the agent can
+act on it.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Run the setup script from inside your piscine repository:
 
 ```bash
 wget -qO- https://raw.githubusercontent.com/qlrd/monsieur-ganesha/main/install.sh | bash
+# or
+curl -fsSL https://raw.githubusercontent.com/qlrd/monsieur-ganesha/main/install.sh | bash
 ```
 
 The script will:

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 HOOKS_REPO="https://github.com/qlrd/monsieur-ganesha"
 CONFIG_FILE=".pre-commit-config.yaml"
 TOML_FILE=".ganesha.toml"
+DAWON_TOML=".dawon.toml"
 
 echo "==> monsieur-ganesha: configurando hooks para piscine 42..."
 
@@ -31,7 +32,7 @@ if [ ! -f "$CONFIG_FILE" ]; then
     cat > "$CONFIG_FILE" <<EOF
 repos:
   - repo: $HOOKS_REPO
-    rev: v0.1.0
+    rev: v0.1.2
     hooks:
       - id: norminette
       - id: c-compiler
@@ -65,7 +66,25 @@ else
     echo "  -> $TOML_FILE já existe, pulando."
 fi
 
-# 5. Instalar hooks no git
+# 5. Criar .dawon.toml template se não existir (companion evaluator)
+if [ ! -f "$DAWON_TOML" ]; then
+    echo "  -> Criando $DAWON_TOML (template para dawon)..."
+    cat > "$DAWON_TOML" <<'EOF'
+[project]
+# Módulo atual: C00, C01, rush00, etc.
+# module = "C00"
+
+[checks]
+# Descomente para desativar checks opcionais:
+# no_sanitizers = true
+# no_valgrind   = true
+EOF
+    echo "     Criado! Edite .dawon.toml se necessário."
+else
+    echo "  -> $DAWON_TOML já existe, pulando."
+fi
+
+# 6. Instalar hooks no git
 echo "  -> Instalando hooks no git..."
 pre-commit install
 pre-commit install --hook-type commit-msg
@@ -77,3 +96,4 @@ echo "Próximos passos:"
 echo "  1. Edite .ganesha.toml com as funções proibidas do seu subject"
 echo "  2. Teste: git add . && git commit -m 'feat: minha implementação'"
 echo "  3. Check manual: pre-commit run --all-files"
+echo "  4. Antes de dar push: dawon check --path . (se dawon estiver instalado)"


### PR DESCRIPTION
## Summary

- Creates `.dawon.toml` template alongside `.ganesha.toml` so the
  companion evaluator is ready to use after install
- Bumps the generated `.pre-commit-config.yaml` rev from `v0.1.0` to
  `v0.1.2`
- Adds a reminder in the post-install output to run
  `dawon check --path .` before pushing

## Test plan

- [ ] Run `install.sh` in a fresh directory — `.dawon.toml` is created
- [ ] Generated `.pre-commit-config.yaml` uses `rev: v0.1.2`
- [ ] Existing `.dawon.toml` is not overwritten

Refs qlrd/dawon#44

🤖 Generated with [Claude Code](https://claude.com/claude-code)